### PR TITLE
Fix machines stop working after recipe change.

### DIFF
--- a/src/main/java/com/smashingmods/alchemylib/api/recipe/AbstractProcessingRecipe.java
+++ b/src/main/java/com/smashingmods/alchemylib/api/recipe/AbstractProcessingRecipe.java
@@ -66,4 +66,9 @@ public abstract class AbstractProcessingRecipe implements ProcessingRecipe, Comp
     public boolean canCraftInDimensions(int pWidth, int pHeight) {
         return false;
     }
+
+    @Override
+    public boolean equals(Object pOther) {
+        return pOther instanceof AbstractProcessingRecipe recipe && compareTo(recipe) == 0;
+    }
 }


### PR DESCRIPTION
Recipe object is copied when recipe change is detected, but `equals` of `AbstractProcessingRecipe` is not implemented, causing tiles to constantly think that the recipe has changed, resetting the progress back to 0. This change fixes the issue.